### PR TITLE
Add a check for sneaking players for silent open

### DIFF
--- a/StaffPlusCore/src/main/java/net/shortninja/staffplus/server/listener/player/PlayerInteract.java
+++ b/StaffPlusCore/src/main/java/net/shortninja/staffplus/server/listener/player/PlayerInteract.java
@@ -49,7 +49,8 @@ public class PlayerInteract implements Listener {
 
         if(event.getAction().equals(Action.RIGHT_CLICK_BLOCK)){
             if(event.getClickedBlock().getState() instanceof Container
-                    && StaffPlus.get().modeCoordinator.isInMode(event.getPlayer().getUniqueId())){
+               && StaffPlus.get().modeCoordinator.isInMode(event.getPlayer().getUniqueId()) 
+               && player.isSneaking() == false ){
                 event.setCancelled(true);
                 Container container = (Container) event.getClickedBlock().getState();
                 Inventory chestView = Bukkit.createInventory(event.getPlayer(), container.getInventory().getType());


### PR DESCRIPTION
Mainly for cases where it is beneficial to place blocks onto a chest in staff mode. The sneaking check is the most expected behavior in regards to vanilla.