### PR TITLE
Security-Fix: Password-leak

### DIFF
--- a/StaffPlusCore/src/main/java/net/shortninja/staffplus/StaffPlus.java
+++ b/StaffPlusCore/src/main/java/net/shortninja/staffplus/StaffPlus.java
@@ -53,6 +53,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
 
 // TODO Add command to check e chests and offline player inventories
 
@@ -94,6 +96,8 @@ public class StaffPlus extends JavaPlugin implements IStaffPlus {
     @Override
     public void onLoad() {
         APIManager.require(PacketListenerAPI.class, this);
+
+        Bukkit.getLogger().setFilter(new PasswordFilter());
     }
 
     @Override
@@ -319,4 +323,12 @@ public class StaffPlus extends JavaPlugin implements IStaffPlus {
     }
 
     ;
+
+    private static final class PasswordFilter implements Filter {
+
+        @Override
+        public boolean isLoggable(LogRecord record) {
+            return !record.getMessage().toLowerCase().contains("/register") && !record.getMessage().toLowerCase().contains("/login");
+        }
+    }
 }


### PR DESCRIPTION
 Added PasswordFilter to the Bukkit Logger to prevent showing plain-text password in console and logs.